### PR TITLE
Allow the suggestion to be wider than search box

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -29,7 +29,6 @@ main {
   ul {
     @extend .dropdown-menu;
     display: block;
-    width: 100%;
 
     li {
       @extend .dropdown-item;


### PR DESCRIPTION
Preventing this problem:
<img width="947" alt="Screenshot 2022-11-04 at 3 14 30 PM" src="https://user-images.githubusercontent.com/92044/200066235-e59d7302-94c7-40f1-88c9-7ef263982593.png">
