### PR TITLE
Add a custom header component for the virtual_tribunals page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Naming/PredicateName:
   ForbiddenPrefixes:
     - _is
 
+RSpec/ExampleLength:
+  Max: 10
+
 RSpec/MultipleExpectations:
   Max: 5
 

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Draws the correct header, either for the virtual tribunals or the Nuremberg Archives
+class HeaderComponent < Arclight::HeaderComponent
+  def call
+    if controller_name == 'virtual_tribunals'
+      render VirtualTribunals::HeaderComponent.new(blacklight_config:)
+    else
+      render Arclight::HeaderComponent.new(blacklight_config:)
+    end
+  end
+end

--- a/app/components/virtual_tribunals/header_component.html.erb
+++ b/app/components/virtual_tribunals/header_component.html.erb
@@ -1,0 +1,11 @@
+<%= top_bar %>
+
+<div class='bg-faded al-masthead'>
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-md-8" >
+        <span class="h1"><%= t('.title') %></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/virtual_tribunals/header_component.rb
+++ b/app/components/virtual_tribunals/header_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module VirtualTribunals
+  # This removes the History and locale picker links.
+  class HeaderComponent < Blacklight::HeaderComponent
+    def initialize(blacklight_config:)
+      @blacklight_config = blacklight_config
+      super
+    end
+    attr_reader :blacklight_config
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@
 class ApplicationController < ActionController::Base
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
-  include Blacklight::LocalePicker::Concern
   layout :determine_layout if respond_to? :layout
+
+  # This helps decide whether some nav actions appear
+  def main_page?
+    controller_name == 'virtual_tribunals'
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,6 +4,7 @@
 class CatalogController < ApplicationController # rubocop:disable Metrics/ClassLength
   include Blacklight::Catalog
   include Arclight::Catalog
+  include Blacklight::LocalePicker::Concern
 
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
@@ -44,15 +45,15 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
       'collection.rows': 1
     }
 
-    config.header_component = Arclight::HeaderComponent
+    config.header_component = HeaderComponent
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control')
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)
 
-    config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark')
-    config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
+    config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', unless: :main_page?)
+    config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history', unless: :main_page?)
 
     # solr field configuration for search results/index views
     config.index.partials = %i[arclight_index_default]

--- a/app/controllers/virtual_tribunals_controller.rb
+++ b/app/controllers/virtual_tribunals_controller.rb
@@ -3,4 +3,10 @@
 # Draws the front page
 class VirtualTribunalsController < ApplicationController
   def index; end
+
+  # This is the content of the <title> tag
+  def render_page_title
+    t('virtual_tribunals.header_component.title')
+  end
+  helper_method :render_page_title
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,12 @@
 en:
   arclight:
-    masthead_heading: Virtual Tribunals
+    masthead_heading: Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46
     views:
       show:
         embedded_content: Digital content
   routes:
     about: About
     inventory: Content inventory
+  virtual_tribunals:
+    header_component:
+      title: Virtual Tribunals at Stanford

--- a/spec/components/header_component_spec.rb
+++ b/spec/components/header_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HeaderComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/components/virtual_tribunals/header_component_spec.rb
+++ b/spec/components/virtual_tribunals/header_component_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VirtualTribunals::HeaderComponent, type: :component do
+  let(:blacklight_config) { controller.blacklight_config }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(nil)
+    render_inline(described_class.new(blacklight_config:))
+  end
+
+  it "renders something useful" do
+    expect(page).to have_text "Virtual Tribunals at Stanford"
+  end
+end

--- a/spec/requests/home_page_spec.rb
+++ b/spec/requests/home_page_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "The home page" do
   it "is a custom page that introduces the project" do
     get "/"
     expect(response).to have_http_status(:ok)
+    expect(page).to have_text "Virtual Tribunals at Stanford"
     expect(page).to have_text 'Content goes here'
   end
 end

--- a/spec/requests/nuremberg_landing_page_spec.rb
+++ b/spec/requests/nuremberg_landing_page_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "The Nuremberg landing page" do
   it "is a custom page that introduces the project" do
     get "/nuremberg"
     expect(response).to have_http_status(:ok)
+    expect(page).to have_text "Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46"
     expect(page).to have_text 'Placeholder text'
     expect(page).to have_link "Bookmarks"
     expect(page).to have_link "History"


### PR DESCRIPTION
Updates the topbar and masthead to make the virtual tribunals page distinct from the NTA page.

Fixes #166 