### PR TITLE
Add text, content warning, explore section to home

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -11,6 +11,7 @@ $logo-height: 35px;
 @import 'blacklight-frontend/app/assets/stylesheets/blacklight/blacklight';
 @import 'arclight/app/assets/stylesheets/arclight/application';
 @import 'sulFooter';
+@import 'home';
 
 body {
   display: flex;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,26 @@
+.global-warning {
+  background-color: $stanford-fog-light;
+  border-color: $stanford-fog;
+
+  span {
+    font-weight: 600;
+  }
+}
+
+.explore {
+  @extend .my-4;
+  
+  .card {
+    background-color: $stanford-fog-light;
+    text-align: center;
+
+    .badge {
+      background-color: $stanford-stone;
+      font-weight: 500;
+    }
+
+    h3 {
+      @extend .h5;
+    }
+  }
+}

--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -13,3 +13,4 @@ $stanford-digital-red: #b1040e;
 // https://identity.stanford.edu/design-elements/color/accent-colors/
 $stanford-fog: #dad7cb;
 $stanford-fog-light: #f4f4f4;
+$stanford-stone: #7F7776;

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,8 +1,86 @@
-<p>Placeholder text. The Nuremberg Trial Archives is.... 
-Lorem ipsum dolor sit amet tempor cras sapien pharetra sagittis do. 
-Id fusce nibh praesent laoreet sodales sagittis neque duis convallis 
-ornare justo platea. Pretium adipiscing senectus nisi eget feugiat netus 
-pharetra massa nibh elit lobortis ac. Nibh pulvinar odio tincidunt eget 
-nullam mi ullamcorper porttitor turpis eleifend sodales facilisi pharetra 
-suspendisse. Imperdiet platea laoreet lacus dictum leo feugiat hac lacinia 
-ultrices feugiat.</p>
+<p>The Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-1946 archival collection collects, for the first time, all of the Nuremberg IMT documentation, including film, audio recordings, photographs, and all of the massive body of records, transcripts, evidence, minutes of meetings, and other documents, online in one location. All [9999] items in this collection are searchable and viewable in digital form.</p>
+
+<div class="alert global-warning">
+  <span>Content warning:</span> [Sentence that provides further context.] Stanford Libraries collects and makes these materials available to facilitate scholarly research and education, and does not endorse the viewpoints within. Our collections may contain language, images, or content that are offensive or harmful.
+</div>
+
+<div class="row explore">
+  <h2 class="h3">Explore the collection</h2>
+
+  <div class="col-sm-4">
+    <div class="card mb-3 mb-sm-0">
+      <img src="https://via.placeholder.com/360x240" class="card-img-top" alt="">
+      <div class="card-body">
+        <h3 class="card-title">Media format</h3>
+        <div class="facet-links">
+          <a href="#">
+            <span class="badge">Images</span>
+          </a>
+          <a href="#">
+            <span class="badge">Sound</span>
+          </a>
+          <a href="#">
+            <span class="badge">Text</span>
+          </a>
+          <a href="#">
+            <span class="badge">Video</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-4">
+    <div class="card mb-3 mb-sm-0">
+      <img src="https://via.placeholder.com/360x240" class="card-img-top" alt="">
+      <div class="card-body">
+        <h3 class="card-title">Document type</h3>
+        <div class="facet-links">
+          <a href="#">
+            <span class="badge">Court transcripts</span>
+          </a>
+          <a href="#">
+            <span class="badge">Exhibits</span>
+          </a>
+          <a href="#">
+            <span class="badge">Pleas</span>
+          </a>
+          <a href="#">
+            <span class="badge">Rulings</span>
+          </a>
+          <a href="#">
+            <span class="badge">more...</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+    <div class="col-sm-4">
+    <div class="card mb-3 mb-sm-0">
+      <img src="https://via.placeholder.com/360x240" class="card-img-top" alt="">
+      <div class="card-body">
+        <h3 class="card-title">Document format</h3>
+        <div class="facet-links">
+          <a href="#">
+            <span class="badge">Book</span>
+          </a>
+          <a href="#">
+            <span class="badge">Envelope</span>
+          </a>
+          <a href="#">
+            <span class="badge">Film</span>
+          </a>
+          <a href="#">
+            <span class="badge">Microfilm</span>
+          </a>
+          <a href="#">
+            <span class="badge">more...</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<h2 class="h3">More about the project</h2>
+
+<p>The Taube IMT collection is part of the <a href="https://humanrights.stanford.edu">Stanford Center for Human Rights and International Justice</a>'s <a href="https://humanrights.stanford.edu/digital-archives-and-new-technologies/virtual-tribunals-initiative-wwii-trial-records-collections">Virtual Tribunal initiative</a>. This project makes a significant contribution to the international community’s cooperative efforts to ensure the long-term preservation of Virtual Tribunal archives. We anticipate continuing to grow this site with additional post-WWII collections from the U.S. Military War Crimes Trials in Europe and in the Far East. Beyond that, other forthcoming collections from more recent international criminal tribunals will include video and audio recordings of court proceedings, alongside transcripts, and evidence presented at trial.</p>

--- a/spec/requests/nuremberg_landing_page_spec.rb
+++ b/spec/requests/nuremberg_landing_page_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "The Nuremberg landing page" do
     get "/nuremberg"
     expect(response).to have_http_status(:ok)
     expect(page).to have_text "Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46"
-    expect(page).to have_text 'Placeholder text'
+    expect(page).to have_text 'items in this collection are searchable and viewable in digital form'
     expect(page).to have_link "Bookmarks"
     expect(page).to have_link "History"
   end


### PR DESCRIPTION
Everything here is still preliminary but this PR makes the NTA home page a bit more realistic and should make it easier to get feedback and revise things to be more final.

I expect the first and last paragraphs and the content warning text to revised when Lauren has time to think about them more fully.

The Explore section will need to be revised in several ways when we are further along with the data:
- Select the three facets best for highlighting the range of material in the collection (these might be the best three, but we'll see)
- Update and link the sample values for each facet card to search results with that facet value selected
- Find a representative image from an item to add to the card (I don't want to take the time to find and prepare good images until I'm certain we're going to go with this Explore section as it is here)

<img width="1182" alt="Screen Shot 2022-11-11 at 1 38 23 PM" src="https://user-images.githubusercontent.com/101482/201428872-aac6aaa4-ac74-4dff-af22-7a45f9790446.png">
