### PR TITLE
Update path of the NTA Home link

### DIFF
--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -1,6 +1,6 @@
 <%# overriding arclight template to display different links %>
 <li class="nav-item">
-  <%= link_to t('arclight.routes.home'), root_path, class: 'nav-link' %>
+  <%= link_to t('arclight.routes.home'), search_catalog_path, class: 'nav-link' %>
 </li>
 <li class="nav-item ms-3">
   <%= link_to t('routes.inventory'), solr_document_path(id: 'mt839rq8746'), class: 'nav-link' %>


### PR DESCRIPTION
The Home link on the NTA site currently points to the VT landing page. The intention for the Home link is actually to bring the user back to the NTA home page, from other pages on the site (search results, a component page, etc.). 

<img width="1166" alt="Screen Shot 2022-11-15 at 10 17 59 AM" src="https://user-images.githubusercontent.com/101482/201985249-cb63a573-1120-4258-9e38-a93f7e81cda5.png">

---

It's true this means there is no link back to the VT landing page for the user on the NTA site, but I think that's fine. Once the user is on the NTA site the VT landing page doesn't provide them with any useful information (they already know about the NTA site and the About link tells them about the VT exhibits site). 