### PR TITLE
Update text of general content warning

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,7 +1,7 @@
 <p>The Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-1946 archival collection collects, for the first time, all of the Nuremberg IMT documentation, including film, audio recordings, photographs, and all of the massive body of records, transcripts, evidence, minutes of meetings, and other documents, online in one location. All [9999] items in this collection are searchable and viewable in digital form.</p>
 
 <div class="alert global-warning">
-  <span>Content warning:</span> [Sentence that provides further context.] Stanford Libraries collects and makes these materials available to facilitate scholarly research and education, and does not endorse the viewpoints within. Our collections may contain language, images, or content that are offensive or harmful.
+  <span>Content warning:</span> Users are advised that material in Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46 contains language and imagery depicting human rights violations, ethnic cleansing, acts of genocide, wartime violence, and offensive stereotypes of people and cultures. Stanford Libraries makes this material available to facilitate scholarly research and education, and does not endorse the viewpoints within.
 </div>
 
 <div class="row explore">


### PR DESCRIPTION
Closes #188.

Updates the content warning text on the home page, based on @laurensorensen suggestion in https://github.com/sul-dlss/vt-arclight/issues/190#issuecomment-1317872527:

<img width="854" alt="Screen Shot 2022-11-17 at 10 44 13 AM" src="https://user-images.githubusercontent.com/101482/202519277-4d185346-a0da-4319-888a-b8b3bf8cd9b4.png">
