### PR TITLE
Increase HTTP timeout for SolrWriter

### DIFF
--- a/lib/traject/vt_config.rb
+++ b/lib/traject/vt_config.rb
@@ -4,6 +4,7 @@ require 'arclight'
 
 settings do
   provide 'component_traject_config', File.join(__dir__, 'vt_component_config.rb')
+  provide 'solr_writer.http_timeout', 1200
 end
 
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))


### PR DESCRIPTION
Don't think we also need to set this in the `vt_component_config` settings