### PR TITLE
Fix link on landing page

### DIFF
--- a/app/views/virtual_tribunals/index.html.erb
+++ b/app/views/virtual_tribunals/index.html.erb
@@ -9,9 +9,7 @@
       </p>
     </div>
     <div class="item-image">
-      <%= link_to search_catalog_path do %>
-        <%= image_tag 'landing-page-CHRIJ-homepage.png', class: 'card-img-top shadow-sm', alt:'' %>
-      <% end %>
+      <%= link_to image_tag('landing-page-CHRIJ-homepage.png', class: 'card-img-top shadow-sm', alt:''), 'https://humanrights.stanford.edu' %>
     </div>
   </div>
 


### PR DESCRIPTION
Just added the correct link for the first image on the landing page - it was meant to go to the CHRIJ site.