### PR TITLE
Add margin to download icon

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -13,6 +13,7 @@ $logo-height: 35px;
 @import 'sulFooter';
 @import 'landingPage';
 @import 'home';
+@import 'sidebar';
 
 body {
   display: flex;

--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -1,0 +1,3 @@
+.bi-download {
+  @extend .me-1
+}


### PR DESCRIPTION
This adds the same small amount of right margin to the download icon as we're using on the info icon, since it is currently a little tight to the button label.

(Not sure what our philosophy is about granularity of our SCSS files, but I created a new one here because I expect we will make other future styling updates to the sidebar and I don't want to just pile things into `application.scss`.)

### Before
<img width="319" alt="Screen Shot 2022-11-17 at 4 49 09 PM" src="https://user-images.githubusercontent.com/101482/202584343-e8c32f4f-bd5a-40f2-b405-c5e2fda6703f.png">


### After
<img width="319" alt="Screen Shot 2022-11-17 at 4 48 13 PM" src="https://user-images.githubusercontent.com/101482/202584340-49d24c69-f3e7-4444-84f2-c402a06e1925.png">
