### PR TITLE
Update destination of main menu About link

### DIFF
--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -6,5 +6,5 @@
   <%= link_to t('routes.inventory'), solr_document_path(id: 'mt839rq8746'), class: 'nav-link' %>
 </li>
 <li class="nav-item ms-3">
-  <%= link_to t('routes.about'), 'https://exhibits.stanford.edu/virtual-tribunals/about/about-the-project', class: 'nav-link' %>
+  <%= link_to t('routes.about'), root_path, class: 'nav-link' %>
 </li>


### PR DESCRIPTION
This PR changes the destination of the main menu About link to go to the VT landing page instead of the VT exhibit about page.

@laurensorensen mentioned that with the forthcoming contextual text the updated landing page might offer good "about" content, and I think even before we get those updates the current VT landing page is as good a destination for the About link as the VT exhibit (especially since that landing page itself points to the VT exhibit). So we might as well just change that link now.