### PR TITLE
Visual design changes

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -43,6 +43,13 @@ main {
 
 .al-masthead + .navbar-search {
   border: 0; // overriding the style from arclight
+  border-bottom: 1px solid $whisper;
+}
+
+.al-masthead .navbar-nav .nav-link {
+  color: $link-color;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .navbar-search {
@@ -77,4 +84,12 @@ main {
       content: '';
     }
   }
+}
+
+.facet-limit-active .card-header {
+  background-color: $stanford-black-20 !important;
+}
+
+.facet-values li .selected {
+  color: $stanford-digital-green !important;
 }

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -14,6 +14,7 @@ $logo-height: 35px;
 @import 'landingPage';
 @import 'home';
 @import 'sidebar';
+@import 'component';
 
 body {
   display: flex;

--- a/app/assets/stylesheets/bootstrapOverrides.scss
+++ b/app/assets/stylesheets/bootstrapOverrides.scss
@@ -1,3 +1,3 @@
-.facet-values li .selected {
-  color: $body-color !important;
+h2, h3, h4, h5, h6 {
+  color: $stanford-cool-grey;
 }

--- a/app/assets/stylesheets/bootstrapVariables.scss
+++ b/app/assets/stylesheets/bootstrapVariables.scss
@@ -5,6 +5,8 @@ $info: $stanford-digital-blue;
 $success: $stanford-fog;
 $dark: $stanford-cardinal;
 
+$body-color: $stanford-black;
+
 // Links
 $link-color: $stanford-cardinal;
 $link-decoration: none; // no underline
@@ -23,6 +25,9 @@ $modal-backdrop-opacity: 0.8;
 $table-border-color: $silver-sand;
 $table-group-separator-color: $silver-sand;
 
+// Borders
+$border-color: $stanford-black-20;
+
 // Breadcrumbs
 $breadcrumb-divider: quote("»");
 
@@ -37,3 +42,10 @@ nav .navbar-nav {
 
 // Forms
 $form-text-color: black; // Better contrast for accessability
+
+// Cards
+$card-cap-bg: $cyan-blue-light;
+$card-border-color: $stanford-black-20;
+
+// Off-canvas
+$offcanvas-bg-color: $whisper;

--- a/app/assets/stylesheets/component.scss
+++ b/app/assets/stylesheets/component.scss
@@ -1,7 +1,28 @@
 .blacklight-catalog-show {
+  .al-collection-content-icon {
+    fill: $stanford-cool-grey;
+  }
+
+  .al-show-sub-heading {
+    color: $stanford-black;
+  }
+
+  .al-number-of-children-badge {
+    background-color: $cyan-blue-light !important;
+    border: 0.75px solid $stanford-black-20;
+    color: $stanford-cool-grey;
+  }
+
+  .dl-invert dt {
+    color: $stanford-cool-grey;
+  }
+
+  .show-document h1 {
+    @extend .h3;
+  }
 
   // Adjustments for sidebar styling that are only applicable
-  // when the sidebar is not collapsed (as on mobile).
+  // when the sidebar is *not* collapsed (as it is on mobile).
   @media (min-width: 992px) {
     .al-masthead + .navbar-search {
       margin-bottom: 0;
@@ -11,12 +32,13 @@
       margin-top: 0 !important;
     }
 
-    section {
+    .show-document,
+    .collection-sidebar {
       padding-top: 2rem;
+    }
 
-      &.show-document {
-        padding-left: 2rem !important;
-      }
+    .show-document {
+      padding-left: 2rem !important;
     }
   }
 }

--- a/app/assets/stylesheets/component.scss
+++ b/app/assets/stylesheets/component.scss
@@ -1,0 +1,22 @@
+.blacklight-catalog-show {
+
+  // Adjustments for sidebar styling that are only applicable
+  // when the sidebar is not collapsed (as on mobile).
+  @media (min-width: 992px) {
+    .al-masthead + .navbar-search {
+      margin-bottom: 0;
+    }
+
+    > .container {
+      margin-top: 0 !important;
+    }
+
+    section {
+      padding-top: 2rem;
+
+      &.show-document {
+        padding-left: 2rem !important;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,6 +1,6 @@
 .global-warning {
-  background-color: $stanford-fog-light;
-  border-color: $stanford-fog;
+  background-color: $cyan-blue-light;
+  border-color: $stanford-black-20;
   font-size: 0.938rem;
 
   span {
@@ -9,19 +9,18 @@
 }
 
 .explore {
-  @extend .my-4;
-  
   .card {
-    background-color: $stanford-fog-light;
-    border-color: $silver-sand;
+    background-color: $cyan-blue-light;
+    border-color: $stanford-black-20;
     text-align: center;
 
     .card-body {
-      border-top: 1px solid $silver-sand;
+      border-top: 1px solid $stanford-black-20;
     }
 
     .badge {
-      background-color: $stanford-stone;
+      background-color: $stanford-black-20;
+      color: $stanford-black;
       font-weight: 500;
     }
 
@@ -29,4 +28,11 @@
       @extend .h5;
     }
   }
+}
+
+.home-heading {
+  border-bottom: 1px solid $stanford-black-20;
+  margin-bottom: 0.75rem;
+  margin-top: 2rem;
+  padding-bottom: 0.5rem;
 }

--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -1,8 +1,10 @@
 // https://identity.stanford.edu/design-elements/color/primary-colors/
 $stanford-cardinal: #8c1515;
 $stanford-cool-grey: #53565a; // used in SDR header (not yet added)
+$stanford-black: #2e2d29; // "100% black" in Stanford brand identity
 $tapa: #767674; // "60% black" in Stanford brand identity
 $silver-sand: #c0c0bf; // "30% black" in Stanford brand identity
+$stanford-black-20: #d5d5d4; // "20% black" in Stanford brand identity
 $whisper: #eaeaea; // "10% black" in Stanford brand identity, used as modal bg color
 
 // https://identity.stanford.edu/design-elements/color/web/
@@ -15,3 +17,7 @@ $stanford-fog: #dad7cb;
 $stanford-fog-light: #f4f4f4;
 $stanford-stone: #7F7776;
 $stanford-stone-light: #D4D1D1;
+
+// Non-Stanford identity colors
+$cyan-blue-light: #f8f9fa;
+$gray-light: #fafafa;

--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -1,3 +1,16 @@
 .bi-download {
   @extend .me-1
 }
+
+.collection-sidebar {
+  box-shadow: 1px 0 1px -1px rgba(0,0,0,0.06),
+    2px 0 2px -2px rgba(0,0,0,0.06),
+    4px 0 4px -4px rgba(0,0,0,0.06),
+    8px 0 8px -8px rgba(0,0,0,0.06),
+    16px 0 16px -16px rgba(0,0,0,0.06);
+
+  @media (max-width: 991px) {
+    border-right: none;
+    box-shadow: none;
+  }
+}

--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -13,4 +13,19 @@
     border-right: none;
     box-shadow: none;
   }
+
+  h2 {
+    font-size: 1.375rem;
+  }
+
+  .al-show-actions-box {
+    background-color: $gray-light;
+    border-radius: 3px;
+  }
+
+  .al-sidebar-navigation-context .nav-item > a {
+    color: $stanford-black;
+    padding-bottom: 0.125rem !important;
+    padding-top: 0.125rem !important;
+  }
 }

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -4,9 +4,9 @@
   <span>Content warning:</span> Users are advised that material in Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46 contains language and imagery depicting human rights violations, ethnic cleansing, acts of genocide, wartime violence, and offensive stereotypes of people and cultures. Stanford Libraries makes this material available to facilitate scholarly research and education, and does not endorse the viewpoints within.
 </div>
 
-<div class="row explore">
-  <h2 class="h3">Explore the collection</h2>
+<h2 class="h4 home-heading">Explore the collection</h2>
 
+<div class="row explore">
   <div class="col-sm-4">
     <div class="card mb-3 mb-sm-0">
       <%= image_tag 'explore-facet-doc-type.png', class: 'card-img-top', alt:'' %>
@@ -81,6 +81,6 @@
   </div>
 </div>
 
-<h2 class="h3">More about the project</h2>
+<h2 class="h4 home-heading">More about the project</h2>
 
 <p>The Taube IMT collection is part of the <a href="https://humanrights.stanford.edu">Stanford Center for Human Rights and International Justice</a>'s <a href="https://humanrights.stanford.edu/digital-archives-and-new-technologies/virtual-tribunals-initiative-wwii-trial-records-collections">Virtual Tribunal initiative</a>. This project makes a significant contribution to the international community’s cooperative efforts to ensure the long-term preservation of Virtual Tribunal archives. We anticipate continuing to grow this site with additional post-WWII collections from the U.S. Military War Crimes Trials in Europe and in the Far East. Beyond that, other forthcoming collections from more recent international criminal tribunals will include video and audio recordings of court proceedings, alongside transcripts, and evidence presented at trial.</p>


### PR DESCRIPTION
This adjusts a bunch of styling-related things, though overall nothing is spectacularly different. Basically I tried to move towards more of a gray-scale palette of colors rather than using the Stanford light beigey colors.

Also styled the sidebar when you are in the collection/component pages, pretty much copying Duke. 

A lot more can be done, but I wanted to get a first pass in before trying to refine things too much.

## Examples

<img width="1199" alt="Screen Shot 2022-11-23 at 10 55 45 AM" src="https://user-images.githubusercontent.com/101482/203617233-0efebe85-3151-4fc7-a86f-d8882cda172c.png">

<img width="1199" alt="Screen Shot 2022-11-23 at 10 56 20 AM" src="https://user-images.githubusercontent.com/101482/203617248-372d3af4-dccd-40e9-b1c2-7a00cf19851c.png">

<img width="1199" alt="Screen Shot 2022-11-23 at 10 56 44 AM" src="https://user-images.githubusercontent.com/101482/203617253-4e3897bd-1fc6-4378-83b2-1f3eb0b2eebc.png">



