### PR TITLE
Update global content warning box styling

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,7 +1,20 @@
 .global-warning {
   background-color: $cyan-blue-light;
   border-color: $stanford-black-20;
-  font-size: 0.938rem;
+  font-size: $font-size-sm;
+  padding: 0.75rem;
+
+  display: flex;
+  align-items: center;
+
+  .warning-icon {
+    color: $stanford-cool-grey;
+    margin-right: 1.5rem;
+
+    @media (max-width: 767px){
+      display: none;
+    }
+  }
 
   span {
     font-weight: 600;

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,7 +1,14 @@
 <p>The Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-1946 archival collection collects, for the first time, all of the Nuremberg IMT documentation, including film, audio recordings, photographs, and all of the massive body of records, transcripts, evidence, minutes of meetings, and other documents, online in one location. All [9999] items in this collection are searchable and viewable in digital form.</p>
 
 <div class="alert global-warning">
-  <span>Content warning:</span> Users are advised that material in Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46 contains language and imagery depicting human rights violations, ethnic cleansing, acts of genocide, wartime violence, and offensive stereotypes of people and cultures. Stanford Libraries makes this material available to facilitate scholarly research and education, and does not endorse the viewpoints within.
+  <div class="warning-icon">
+    <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
+      <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+    </svg>
+  </div>
+  <div>
+    <span>Content warning:</span> Users are advised that material in Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46 contains language and imagery depicting human rights violations, ethnic cleansing, acts of genocide, wartime violence, and offensive stereotypes of people and cultures. Stanford Libraries makes this material available to facilitate scholarly research and education, and does not endorse the viewpoints within.
+  </div>
 </div>
 
 <h2 class="h4 home-heading">Explore the collection</h2>


### PR DESCRIPTION
Added an icon to the content warning box and adjusted styling a bit, just trying to make it a little more visually interesting.

To save space on mobile, icon only displays on larger viewports.

<img width="980" alt="Screen Shot 2022-11-23 at 2 44 08 PM" src="https://user-images.githubusercontent.com/101482/203651463-5ff57419-49a6-40b3-9e91-035a9e0c7dca.png">
