### PR TITLE
Add gradient to masthead background

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -38,7 +38,10 @@ main {
 }
 
 .al-masthead, .navbar-search {
-  background-color: $stanford-fog-light;
+  background: rgb(213,213,212);
+  background: linear-gradient(145deg,
+    rgba(213,213,212,0.464005585144214) 10%,
+    rgba(244,244,244,1) 95%);
 }
 
 .al-masthead + .navbar-search {


### PR DESCRIPTION
This is just a very subtle enhancement of the masthead, adding a linear gradient (starts darker on the left and gets lighter to the right) to give it a little more texture than a solid bg color.

I have some other potentially more interesting, but complicated, enhancements we might try, but I'll create a ticket for those, and in the meantime we have at least this slightly better masthead.

<img width="1202" alt="Screen Shot 2022-11-23 at 3 06 20 PM" src="https://user-images.githubusercontent.com/101482/203654398-000e2301-0e69-4a25-b100-c0d0667f40b3.png">
