### PR TITLE
Fix underline of facet badges on homepage

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -36,3 +36,11 @@
   margin-top: 2rem;
   padding-bottom: 0.5rem;
 }
+
+.facet-links a:hover {
+  text-decoration: none;
+}
+
+.facet-links a:hover span.badge {
+  text-decoration: underline;
+}


### PR DESCRIPTION
This is the hover state

Before
![Screen Shot 2022-11-28 at 12 30 37](https://user-images.githubusercontent.com/1328900/204343998-72ee25ef-e54e-4663-972b-8114509d8b28.png)



After
![Screen Shot 2022-11-28 at 12 30 25](https://user-images.githubusercontent.com/1328900/204344014-bb00df86-1424-4483-ad1e-8e854853b6c4.png)
