### PR TITLE
Update capybara matcher 

### DIFF
--- a/spec/features/bookmark_spec.rb
+++ b/spec/features/bookmark_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe "Bookmark item", js: true do
     visit "/catalog/#{id}"
 
     check 'Bookmark'
-    expect(page).to have_css('label', text: "In Bookmarks")
+
+    # This selector keeps trying until the javascript has finished updating the label
+    expect(page).to have_xpath('.//label/span/span[contains(text(), "In Bookmarks")]', wait: 10)
 
     click_link 'Bookmarks'
 


### PR DESCRIPTION
The label is always on the page, so it grabs the label and then checks to see if the filters match.  They will not match if the code hasn't finished executing.  The filters are not part of the timeout cycle, so the previous selector may or may not work depending on whether the code has finished executing.