### PR TITLE
Remove ruby declaration from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'blacklight', github: 'projectblacklight/blacklight', branch: 'main'
 gem "rails", "~> 7.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,8 +462,5 @@ DEPENDENCIES
   webdrivers
   webmock
 
-RUBY VERSION
-   ruby 3.1.2p20
-
 BUNDLED WITH
    2.3.22


### PR DESCRIPTION
This prevents installing on other ruby versions, which may prevent upgrading ruby on the server. This aligns with our other ruby projects