### PR TITLE
Don't display the fulltext warning unless a search is present

### DIFF
--- a/app/javascript/controllers/context_result_info_controller.js
+++ b/app/javascript/controllers/context_result_info_controller.js
@@ -3,10 +3,15 @@ import { Controller } from "@hotwired/stimulus"
 // Reveal the element if they haven't permanently dismissed it.
 export default class extends Controller {
   connect() {
-    this.element.hidden = localStorage.getItem('hide-context-result-info')
+    this.element.hidden = !this.#isSearch || localStorage.getItem('hide-context-result-info')
   }
 
   disable() {
     localStorage.setItem('hide-context-result-info', true)
+  }
+
+  get #isSearch() {
+    const urlParams = new URLSearchParams(window.location.search)
+    return Boolean(urlParams.get("q"))
   }
 }


### PR DESCRIPTION
e.g. hide it when selecting a facet, but not providing a search.

Fixes #327