### PR TITLE
Cache the search sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ vault kv get puppet/application/vt/stage/aspace_password
     ```shell
      rake vt:index 
     ```
+5. Clear the caches
+   ```shell
+    cap prod remote_execute["cd vt/current; RAILS_ENV=production bin/rails tmp:cache:clear"]
+   ```
+
 ## Start the app
 
 ### Locally

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,7 +1,9 @@
 <% # this view overrides the Arclight provided view so that we can see the home page text %>
 
 <% content_for(:sidebar) do %>
-  <%= render 'search_sidebar' %>
+  <% cache search_state.to_hash do %>
+    <%= render 'search_sidebar' %>
+  <% end %>
 <% end %>
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :file_store, "tmp/cache"
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
This reduces the time to draw the page to ~600ms after being cached.  This is a 90% improvement.  The drawback here is we need to clear the cache (`bin/rails tmp:cache:clear`) once we reindex if any of the documents change in a way that would affect the facets. 

As this is using a file cache, the two servers do not share a single cache. This could be improved by using a shared cache store. 
Fixes #388