### PR TITLE
Change metadata attributes to use dd with hidden dt

### DIFF
--- a/app/components/metadata_attribute_component.html.erb
+++ b/app/components/metadata_attribute_component.html.erb
@@ -1,1 +1,2 @@
-<%= tag.div @field.render, class: @classes %>
+<%= tag.dt @field.label, class: 'visually-hidden' %>
+<%= tag.dd @field.render, class: @classes %>


### PR DESCRIPTION
This aligns with the usage of dd for semantically representing
metadata of search results, instead of just div. It also
differentiates the actual metadata attributes from things like
the full text display, which fixes #442 because the CSS selector
now targets the last metadata attribute.
