### PR TITLE
Add vertical spacing between main menu and search box

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -37,6 +37,11 @@ main {
   }
 }
 
+.al-masthead h1,
+.al-masthead .h1 {
+  padding-bottom: 1.25rem;
+}
+
 .al-masthead, .navbar-search {
   background: rgb(213,213,212);
   background: linear-gradient(145deg,
@@ -53,6 +58,7 @@ main {
   color: $link-color;
   font-size: 1rem;
   font-weight: 600;
+  padding-bottom: 1rem;
 }
 
 .navbar-search {


### PR DESCRIPTION
There's currently almost no vertical spacing between the site main menu and the search box, which is not great visually but also puts two click target areas very close together:

<img width="1152" alt="Screen Shot 2023-01-06 at 3 33 00 PM" src="https://user-images.githubusercontent.com/101482/211112110-93e4f243-b9cc-443a-aaf8-8339ae7e0c29.png">

---

This PR adds some vertical spacing between those elements (and reduces slightly the padding below the site title to gain back a bit of the extra height added):

<img width="1152" alt="Screen Shot 2023-01-06 at 3 39 22 PM" src="https://user-images.githubusercontent.com/101482/211112214-dd72960a-61b3-4bae-8a41-d7c966ad329a.png">

