### PR TITLE
Implement search with document feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,9 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 20
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
 Gemspec/RequireMFA: # new in 1.23

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -97,6 +97,10 @@ main {
   .full-text {
     font-size: 0.938rem;
 
+    .prepared-search-link {
+      display: block;
+    }
+
     em {
       font-style: normal;
       font-weight: bold;

--- a/app/components/embed_component.html.erb
+++ b/app/components/embed_component.html.erb
@@ -1,6 +1,6 @@
 <div id="embed" class="mb-4">
   <%= content_warning %>
-  <%= render Arclight::OembedViewerComponent.with_collection(embeddable_resources, document: @document) %>
+  <%= render OembedViewerComponent.with_collection(embeddable_resources, document: @document, search: query_param) %>
 
   <% linked_resources.each do |resource| %>
     <div class="al-digital-object">

--- a/app/components/embed_component.rb
+++ b/app/components/embed_component.rb
@@ -5,6 +5,15 @@ class EmbedComponent < Arclight::EmbedComponent
   VIDEO_TYPE = 'Moving Images'
   IMAGE_TYPE = 'Graphic Materials'
 
+  attr_reader :query_param
+
+  def initialize(document:, presenter:, **)
+    super
+
+    # Save the search so we can pass it to the viewer for highlighting
+    @query_param = presenter.view_context.search_state.query_param
+  end
+
   def content_warning
     return unless video? || image?
 

--- a/app/components/full_text_result_component.html.erb
+++ b/app/components/full_text_result_component.html.erb
@@ -1,4 +1,7 @@
 <div class="mt-3 full-text">
+  <%= link_to(t('.prepared_search_link', search: query_param),
+    solr_document_path(@field.document.id, q: query_param),
+    class: 'prepared-search-link') %>
   <%= label %>
   <button class="btn btn-link full-text-expand collapsed ps-0" type="button" data-bs-toggle="collapse" data-bs-target="#<%= key %>" aria-expanded="false" aria-controls="<%= key %>"><span class="visually-hidden">expand</span></button>
   <div id="<%= key %>" class="collapse">

--- a/app/components/full_text_result_component.rb
+++ b/app/components/full_text_result_component.rb
@@ -2,6 +2,15 @@
 
 # Render the fulltext results
 class FullTextResultComponent < Blacklight::MetadataFieldComponent
+  attr_reader :query_param
+
+  def initialize(field:, **)
+    super
+
+    # Save the search so we can pass it to the show page for searching the document
+    @query_param = field.view_context.search_state.query_param
+  end
+
   def key
     "#{@field.key}-#{@field.document.id}"
   end

--- a/app/components/oembed_viewer_component.html.erb
+++ b/app/components/oembed_viewer_component.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div(class: 'al-oembed-viewer', data: viewer_attrs) do %>
+  <div class="al-digital-object">
+    <%= link_to(@resource.label, @resource.href) %>
+  </div>
+<% end %>

--- a/app/components/oembed_viewer_component.rb
+++ b/app/components/oembed_viewer_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Customized oEmbed viewer that can pass extra parameters to sul-embed
+class OembedViewerComponent < Arclight::OembedViewerComponent
+  def initialize(resource:, document:, search:)
+    super(resource:, document:)
+
+    @search = search
+  end
+
+  # Rendered as data-* attributes on the viewer element for Arclight's JS
+  def viewer_attrs
+    {
+      arclight_oembed: true,
+      arclight_oembed_url: @resource.href,
+      arclight_oembed_search: @search
+    }
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,8 @@ en:
     disable_session: Don't show again
   embed_component:
     content_warning_html: <span>Content warning:</span> Imagery and language presented in this archival material may be harmful or traumatizing to some audiences.
+  full_text_result_component:
+    prepared_search_link: Search for "%{search}" in document text
   feedbacks:
     create:
       success: Feedback submitted.

--- a/spec/components/embed_component_spec.rb
+++ b/spec/components/embed_component_spec.rb
@@ -3,13 +3,16 @@
 require "rails_helper"
 
 RSpec.describe EmbedComponent, type: :component do
-  let(:presenter) { instance_double(Arclight::ShowPresenter) }
+  let(:view_context) { controller.view_context }
+  let(:presenter) { Arclight::ShowPresenter.new(document, view_context) }
   let(:document) { instance_double(SolrDocument, media_type:, digital_objects:) }
+  let(:params) { {} }
   let(:digital_objects) do
     [instance_double(Arclight::DigitalObject, href: '#', label: 'hi')]
   end
 
   before do
+    allow(view_context).to receive(:search_state).and_return(Blacklight::SearchState.new(params, nil))
     render_inline(described_class.new(presenter:, document:))
   end
 
@@ -40,6 +43,15 @@ RSpec.describe EmbedComponent, type: :component do
 
     it "shows a warning" do
       expect(page).to have_text 'Content warning'
+    end
+  end
+
+  context 'with an active search' do
+    let(:media_type) { 'Text' }
+    let(:params) { { q: 'foo' } }
+
+    it 'stores the search for passing to the viewer' do
+      expect(described_class.new(presenter:, document:).query_param).to eq 'foo'
     end
   end
 end

--- a/spec/components/full_text_result_component_spec.rb
+++ b/spec/components/full_text_result_component_spec.rb
@@ -1,15 +1,32 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe FullTextResultComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:view_context) { controller.view_context }
+  let(:field_config) { Blacklight::Configuration::Field.new(key: 'ftkey', field: 'fulltext', label: 'Full Text') }
+  let(:document) { SolrDocument.new(id: 123, fulltext: ['my text']) }
+  let(:field) { Blacklight::FieldPresenter.new(view_context, document, field_config) }
+  let(:params) { {} }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  before do
+    allow(view_context).to receive(:search_state).and_return(Blacklight::SearchState.new(params, nil))
+    render_inline(described_class.new(field:))
+  end
+
+  it 'renders the full text content' do
+    expect(page).to have_selector '#ftkey-123', text: 'my text'
+  end
+
+  it 'renders a button to expand the full text preview' do
+    expect(page).to have_button 'expand'
+  end
+
+  context 'with a search active' do
+    let(:params) { { q: 'mytext' } }
+
+    it 'renders a link to search within the document' do
+      expect(page).to have_link 'Search for "mytext" in document text', href: '/catalog/123?q=mytext'
+    end
+  end
 end

--- a/spec/components/oembed_viewer_component_spec.rb
+++ b/spec/components/oembed_viewer_component_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OembedViewerComponent, type: :component do
+  let(:presenter) { instance_double(Arclight::ShowPresenter) }
+  let(:document) { instance_double(SolrDocument) }
+  let(:resource) { instance_double(Arclight::DigitalObject, href: 'example.com', label: 'hi') }
+  let(:search) { 'mytext' }
+
+  before do
+    render_inline(described_class.new(resource:, document:, search:))
+  end
+
+  it 'renders the viewer' do
+    expect(page).to have_selector 'div[data-arclight-oembed="true"]'
+  end
+
+  it 'renders a link to the resource' do
+    expect(page).to have_link 'hi', href: 'example.com'
+  end
+
+  it 'passes the oembed URL to the viewer' do
+    expect(page).to have_selector 'div[data-arclight-oembed-url="example.com"]'
+  end
+
+  it 'passes the search term to the viewer' do
+    expect(page).to have_selector 'div[data-arclight-oembed-search="mytext"]'
+  end
+end


### PR DESCRIPTION
This borrows Exhibits' implementation and creates a link to open
the document with a search active in the embed viewer.

Also adds component tests.

Closes #155
