### PR TITLE
Update home explore card badge styling to intended styling

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -39,10 +39,9 @@
     }
 
     .badge {
-      background-color: $stanford-stone;
-      color: white;
+      background-color: $stanford-black-20;
+      color: $stanford-black;
       font-weight: 500;
-      font-size: $font-size-sm;
     }
 
     h3 {


### PR DESCRIPTION
PR #352 changed the font size and background color of the facet badges in the Explore section cards. This PR reverses those changes back to the original:

<img width="1168" alt="Screen Shot 2023-01-09 at 4 05 56 PM" src="https://user-images.githubusercontent.com/101482/211428490-7823e558-3888-4498-84a1-bd0aee3fd0c4.png">

---

I appreciate that the team went back to my Figma mockups to try to understand my intention for the badge styling, but I'm the one who made the [PR that styled those badges](https://github.com/sul-dlss/vt-arclight/pull/285), and it's impossible to keep my mockups up-to-date with changes to the application, so a recent PR I made should be considered more definitive than an old mockup I made.

The badge background color I used in my mockup was selected before the home page visual design was finalized and is too dark for the finished design. It is now by far the darkest element on the page and attracts the user's eye. The intention of the Explore facet boxes is not to be the most important thing on the page; they are just another thing we use to get the user interested in the site, along with the intro text, the facet sidebar, etc. So that's why in my original PR I used a much lighter and less dominant background color for the badges.

The increase in the badge font size does the same thing. It makes the badges larger, making them more dominant, and increases the height of the cards, which also makes them more dominant on the page. If the cards were the main focal point of the page, I agree, the badge font is quite small and we should increase it to be more readable. But again, the cards are just one alternative to catch the user's attention, and while very small, as @cbeer suggested in the [ticket discussion](https://github.com/sul-dlss/vt-arclight/issues/341#issuecomment-1337525995), that is the default Bootstrap font size for badges. I believe it works fine for the context (although I could probably be persuaded to increase it by 1 pixel).

(Note that I did leave the `text-align: center` on the h3 that was added, assuming @thatbudakguy knows something I don't, although the `.card` already has `text-align: center`, which seems to handle the h3 fine.)