### PR TITLE
Restyle the embed content warning

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,11 +1,13 @@
-.global-warning {
+.warning {
   background-color: $cyan-blue-light;
   border-color: $stanford-black-20;
   font-size: $font-size-sm;
   padding: 0.75rem;
 
-  display: flex;
-  align-items: center;
+  &.global-warning {
+    display: flex;
+    align-items: center;
+  }
 
   .warning-icon {
     color: $stanford-cool-grey;

--- a/app/components/embed_component.rb
+++ b/app/components/embed_component.rb
@@ -8,7 +8,7 @@ class EmbedComponent < Arclight::EmbedComponent
   def content_warning
     return unless video? || image?
 
-    tag.div t('.content_warning_html'), class: "alert global-warning"
+    tag.div t('.content_warning_html'), class: "alert warning"
   end
 
   def video?

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,6 +1,6 @@
 <%= t '.intro_html' %>
 
-<div class="alert global-warning">
+<div class="alert warning global-warning">
   <div class="warning-icon" aria-hidden="true">
     <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
       <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
     dismiss: Dismiss
     disable_session: Don't show again
   embed_component:
-    content_warning_html: <span>Content warning:</span>&nbsp;Imagery and language presented in this archival material may be harmful or traumatizing to some audiences.
+    content_warning_html: <span>Content warning:</span> Imagery and language presented in this archival material may be harmful or traumatizing to some audiences.
   feedbacks:
     create:
       success: Feedback submitted.


### PR DESCRIPTION
The implementation of the Embed page content warning is piggybacking on the home page content warning styling and layout but it doesn't work very well because the Embed version doesn't have an icon, which is why I used flexbox when implementing the home page version. As a result, we get weird alignment, with the warning label breaking into two lines, and a big gap (or no gap, depending on the browser viewport width) between it and the warning text itself. There's also a forced space at the beginning of the content warning text, which results in the first line being one space indented, so multiple lines are not left-aligned:

<img width="752" alt="Screen Shot 2023-01-09 at 4 53 12 PM" src="https://user-images.githubusercontent.com/101482/211433684-81aab605-9c35-4ecb-adb2-f16291c3a1d0.png">

---

<img width="382" alt="Screen Shot 2023-01-09 at 5 07 48 PM" src="https://user-images.githubusercontent.com/101482/211433692-a79166e7-eb37-429f-b405-0e25ce15fc0a.png">

---

This PR adjusts the CSS class names a bit so we can get the common warning box styling from one class, and then only use the flexbox layout for the version that needs it (the home page version). I think the Embed version of the content warning then looks better at all viewport widths (the home page version remains as it was):

<img width="752" alt="Screen Shot 2023-01-09 at 5 05 18 PM" src="https://user-images.githubusercontent.com/101482/211433903-96e9b90a-5bd5-47e8-9879-1021c8b6341a.png">

---


<img width="544" alt="Screen Shot 2023-01-09 at 5 05 39 PM" src="https://user-images.githubusercontent.com/101482/211433923-9bb76f79-a878-4955-99c0-0d2d5a7bc000.png">


