### PR TITLE
Update modal background color

### DIFF
--- a/app/assets/stylesheets/bootstrapVariables.scss
+++ b/app/assets/stylesheets/bootstrapVariables.scss
@@ -16,7 +16,6 @@ $link-hover-decoration: underline;
 $font-family-sans-serif: 'Source Sans Pro', sans-serif;
 
 // Modals
-$modal-content-bg: $whisper;
 $modal-backdrop-bg: white;
 $modal-backdrop-opacity: 0.8;
 


### PR DESCRIPTION
The current modal doesn't standout from the background quite enough, and the current background color is sort of unpleasant-looking in large blocks. This PR just changes it to white to provide more contrast and a better background for reading the text on the page:

## Before

<img width="972" alt="Screen Shot 2023-01-11 at 3 49 45 PM" src="https://user-images.githubusercontent.com/101482/211936466-a0456da6-5125-402a-8a7a-f0db78fecce9.png">

## After
<img width="972" alt="Screen Shot 2023-01-11 at 3 56 52 PM" src="https://user-images.githubusercontent.com/101482/211936485-451738c7-3085-4457-8e37-2f69b12e7e0d.png">
