### PR TITLE
Spacing-related visual design updates

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -51,7 +51,7 @@ main {
 
 .al-masthead + .navbar-search {
   border: 0; // overriding the style from arclight
-  border-bottom: 1px solid $whisper;
+  border-bottom: 1px solid $stanford-black-20;
 }
 
 .al-masthead .navbar-nav .nav-link {
@@ -62,7 +62,7 @@ main {
 }
 
 .navbar-search {
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
 
   > .container {
     justify-content: space-around;  // center the search box

--- a/app/assets/stylesheets/component.scss
+++ b/app/assets/stylesheets/component.scss
@@ -1,4 +1,13 @@
 .blacklight-catalog-show {
+  .al-show-breadcrumb {
+    margin-bottom: 1rem;
+  }
+
+  .title-container {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+
   .al-collection-content-icon {
     fill: $stanford-cool-grey;
   }

--- a/app/components/embed_component.html.erb
+++ b/app/components/embed_component.html.erb
@@ -1,4 +1,4 @@
-<div id="embed" class="mb-2">
+<div id="embed" class="mb-4">
   <%= content_warning %>
   <%= render Arclight::OembedViewerComponent.with_collection(embeddable_resources, document: @document) %>
 


### PR DESCRIPTION
Minor, mostly spacing-related, updates:

- Darkened bottom border on site header
- Added some vertical space, and removed other vertical space, indicated by arrows on the "After" screenshot below
- Removed the border between the component title and the metadata or viewer elements that follow. Felt like we have too many horizontal borders and now that the data is more complete, this one doesn't feel necessary to me.

## Before
<img width="1183" alt="Screen Shot 2023-01-11 at 4 58 45 PM" src="https://user-images.githubusercontent.com/101482/211944052-02113fd6-145e-45cc-802d-048687209723.png">

## After
<img width="1183" alt="Screen Shot 2023-01-11 at 4 57 15 PM" src="https://user-images.githubusercontent.com/101482/211944094-f7c752fd-7b71-4f7c-be3a-ccbd2fdf381a.png">
