### PR TITLE
Adjust styling and behavior of feedback form to match design

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -68,5 +68,14 @@
   &.open {
     max-height: 100vh;
   }
+
+  label {
+    font-weight: 600;
+
+    @media (min-width: 768px) {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
  }
  

--- a/app/components/top_bar_component.html.erb
+++ b/app/components/top_bar_component.html.erb
@@ -16,6 +16,10 @@
     <div class="container mt-3">
       <div class="row justify-content-center">
         <%= form_with url: feedback_path, method: :post, class: 'col-md-8' do |f| %>
+          <%= f.hidden_field :reporting_from, value: request.original_url %>
+          <div class="alert alert-danger" role="alert">
+            <%= t('feedbacks.reporting_from', url: request.original_url) %>
+          </div>
           <div class="mb-3 row">
             <%= f.label :message, class: "col-md-3 col-form-label" %>
             <div class="col-md-9">

--- a/app/components/top_bar_component.html.erb
+++ b/app/components/top_bar_component.html.erb
@@ -42,7 +42,7 @@
           <div class="mb-3 row">
             <div class="col-sm-10 offset-sm-2">
               <%= f.submit class: 'btn btn-primary' %>
-              <%= button_tag "Reset", type: :reset, data: { action: 'feedback#reset' }, class: 'btn btn-link' %>
+              <%= button_tag "Cancel", type: :button, data: { action: 'feedback#cancel' }, class: 'btn btn-link' %>
             </div>
           </div>
         <% end %>

--- a/app/components/top_bar_component.html.erb
+++ b/app/components/top_bar_component.html.erb
@@ -23,7 +23,7 @@
           <div class="mb-3 row">
             <%= f.label :message, class: "col-md-3 col-form-label" %>
             <div class="col-md-9">
-              <%= f.text_area :message, class: 'form-control', required: true %>
+              <%= f.text_area :message, class: 'form-control', rows: 5, required: true %>
             </div>
           </div>
           <div class="mb-3 row">

--- a/app/components/top_bar_component.html.erb
+++ b/app/components/top_bar_component.html.erb
@@ -17,30 +17,30 @@
       <div class="row justify-content-center">
         <%= form_with url: feedback_path, method: :post, class: 'col-md-8' do |f| %>
           <div class="mb-3 row">
-            <%= f.label :message, class: "col-sm-2 col-form-label" %>
-            <div class="col-sm-10">
+            <%= f.label :message, class: "col-md-3 col-form-label" %>
+            <div class="col-md-9">
               <%= f.text_area :message, class: 'form-control', required: true %>
             </div>
           </div>
           <div class="mb-3 row">
-            <%= f.label :name, class: "col-sm-2 col-form-label" %>
-            <div class="col-sm-10">
+            <%= f.label :name, class: "col-md-3 col-form-label" %>
+            <div class="col-md-9">
               <%= f.text_field :name, class: 'form-control', required: true %>
             </div>
           </div>
           <div class="mb-3 row">
-            <%= f.label :email, class: "col-sm-2 col-form-label" %>
-            <div class="col-sm-10">
+            <%= f.label :email, class: "col-md-3 col-form-label" %>
+            <div class="col-md-9">
               <%= f.email_field :email, class: 'form-control', required: true %>
             </div>
           </div>
           <div class="mb-3 row">
-            <div class="col-sm-10 offset-sm-2">
+            <div class="col-md-9 offset-md-3">
               <%= recaptcha_v3(action: 'feedback') %>
             </div>
           </div>
           <div class="mb-3 row">
-            <div class="col-sm-10 offset-sm-2">
+            <div class="col-md-9 offset-md-3">
               <%= f.submit class: 'btn btn-primary' %>
               <%= button_tag "Cancel", type: :button, data: { action: 'feedback#cancel' }, class: 'btn btn-link' %>
             </div>

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,13 +2,17 @@
 
 # Handles submission of the feedback form
 class FeedbacksController < ApplicationController
+  # rubocop:disable Metrics/AbcSize
   def create
     if verify_recaptcha(action: 'feedback')
-      FeedbackMailer.submit_feedback(name: params[:name], email: params[:email], message: params[:message]).deliver_now
+      FeedbackMailer.submit_feedback(name: params[:name], email: params[:email],
+                                     reporting_from: params[:reporting_from],
+                                     message: params[:message]).deliver_now
       redirect_to root_path, notice: t(".success")
     else
       # Score is below threshold, so user may be a bot.
       redirect_to root_path, alert: t(".failure")
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/javascript/controllers/feedback_controller.js
+++ b/app/javascript/controllers/feedback_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     this.containerTarget.classList.toggle('open')
   }
 
-  reset(e) {
+  cancel(e) {
     this.containerTarget.classList.toggle('open')
   }
 }

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -2,9 +2,10 @@
 
 # Creates feedback emails
 class FeedbackMailer < ApplicationMailer
-  def submit_feedback(name:, email:, message:)
+  def submit_feedback(name:, email:, reporting_from:, message:)
     @name = name
     @email = email
+    @reporting_from = reporting_from
     @message = message
     mail(to: Rails.application.config.feedback_email,
          from: 'no-reply@library.stanford.edu')

--- a/app/views/feedback_mailer/submit_feedback.text.erb
+++ b/app/views/feedback_mailer/submit_feedback.text.erb
@@ -1,3 +1,4 @@
 Name: <%= @name %>
 Email: <%= @email %>
+Reporting from: <%= @reporting_from %>
 Message: <%= @message %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     create:
       success: Feedback submitted.
       failure: Unable to send feedback.
+    reporting_from: 'Reporting from: %{url}'
   feedback_mailer:
     submit_feedback:
       subject: Feedback from Virtual Tribunals (Arclight)


### PR DESCRIPTION
@ggeisler maybe you want to take a look at this PR that adjusts the feedback form based on your recent comments on #129 ?

Closes #129 

**Before:**

<img width="1131" alt="Screen Shot 2023-01-18 at 10 01 08 AM" src="https://user-images.githubusercontent.com/458247/213208679-f32765d6-f077-4731-91a1-7b877171d324.png">

**After:**

<img width="1142" alt="Screen Shot 2023-01-18 at 10 00 11 AM" src="https://user-images.githubusercontent.com/458247/213208791-0d35afdd-c1b6-4e9b-ae0f-dd13ff8f4359.png">
<img width="466" alt="Screen Shot 2023-01-18 at 10 00 23 AM" src="https://user-images.githubusercontent.com/458247/213208827-576b50e7-1a29-4886-8595-7762dd088709.png">
