### PR TITLE
Improve styling of search result items

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -77,44 +77,57 @@ main {
   }
 }
 
-.document-metadata {
-  .attribute {
-    display: inline-flex;
-    font-size: 0.938rem;
-    padding-right: 0;
-    width: auto;
-
-    &::after {
-      content: '⸱';
-      padding-left: calc(var(--bs-gutter-x) * .5);
-    }
-
-    &:last-of-type::after {
-      content: '';
-    }
+.documents-list {
+  & article.document dd.al-document-abstract-or-scope {
+    margin-top: 0;
   }
 
-  .full-text {
-    font-size: 0.938rem;
+  .document-metadata {
+    margin-bottom: 0;
 
-    .prepared-search-link {
-      display: block;
-    }
+    .attribute {
+      display: inline-flex;
+      font-size: 0.938rem;
+      padding-right: 0;
+      width: auto;
 
-    em {
-      font-style: normal;
-      font-weight: bold;
-    }
-
-    .full-text-expand {
       &::after {
-        content: "▶";
-        float: right;
-        transform: rotate(90deg);
+        content: '⸱';
+        padding-left: calc(var(--bs-gutter-x) * .5);
       }
-      &.collapsed::after {
-        transform: rotate(0deg);
-        transition: transform 0.1s ease;
+
+      &:last-of-type::after {
+        content: '';
+      }
+    }
+
+    .full-text {
+      font-size: 0.938rem;
+
+      .prepared-search-link {
+        display: block;
+      }
+
+      em {
+        font-style: normal;
+        font-weight: bold;
+      }
+
+      .full-text-expand {
+        &::after {
+          content: "▶";
+          float: right;
+          transform: rotate(90deg);
+        }
+        &.collapsed::after {
+          transform: rotate(0deg);
+          transition: transform 0.1s ease;
+        }
+      }
+
+      .full-text-snippet {
+        border-left: 1px solid $stanford-black-20;
+        padding-left: 1rem;
       }
     }
   }

--- a/app/components/full_text_result_component.html.erb
+++ b/app/components/full_text_result_component.html.erb
@@ -1,10 +1,10 @@
-<div class="mt-3 full-text">
+<div class="mt-1 full-text">
   <%= link_to(t('.prepared_search_link', search: query_param),
     solr_document_path(@field.document.id, q: query_param),
     class: 'prepared-search-link') %>
   <%= label %>
   <button class="btn btn-link full-text-expand collapsed ps-0" type="button" data-bs-toggle="collapse" data-bs-target="#<%= key %>" aria-expanded="false" aria-controls="<%= key %>"><span class="visually-hidden">expand</span></button>
-  <div id="<%= key %>" class="collapse">
+  <div id="<%= key %>" class="full-text-snippet collapse">
     <%= @field.render %>
   </div>
 </div>


### PR DESCRIPTION
Search result items have a bit more whitespace around them than necessary:

<img width="857" alt="Screen Shot 2023-01-19 at 5 05 43 PM" src="https://user-images.githubusercontent.com/101482/213589414-3296814c-bc49-43d3-a7a0-b58ac81a2f1b.png">

---

And the full-text search snippet kind of blends in with the text of the "Sample matches" text above:

<img width="857" alt="Screen Shot 2023-01-19 at 5 06 19 PM" src="https://user-images.githubusercontent.com/101482/213589491-f2dfdb84-7abe-486b-b9d5-0cda8a8a88c8.png">

---
So this PR just compresses the spacing a bit:

<img width="857" alt="Screen Shot 2023-01-19 at 5 00 39 PM" src="https://user-images.githubusercontent.com/101482/213589540-44cc9677-431f-40af-bb6d-c6b4df5b8b6c.png">

---

And adds a left border to highlight the full-text snippet:

<img width="857" alt="Screen Shot 2023-01-19 at 5 00 57 PM" src="https://user-images.githubusercontent.com/101482/213589623-29f31473-04e8-42b7-bd9c-d304f5b267b8.png">


(The diff shows a lot of changes but that's mostly due to me moving existing styles under the parent class I added for this PR's purposes.)
