### PR TITLE
Add small drop shadow to alert box and cards

### DIFF
--- a/app/components/explore_facet_component.html.erb
+++ b/app/components/explore_facet_component.html.erb
@@ -1,5 +1,5 @@
   <div class="col-sm-4">
-    <div class="card mb-3 mb-sm-0">
+    <div class="card shadow-sm mb-3 mb-sm-0">
       <%= image_tag image, class: 'card-img-top', alt:'' %>
       <div class="card-body">
         <h3 class="card-title"><%= title %></h3>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,6 +1,6 @@
 <%= t '.intro_html' %>
 
-<div class="alert warning global-warning">
+<div class="alert warning global-warning shadow-sm">
   <div class="warning-icon" aria-hidden="true">
     <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
       <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>


### PR DESCRIPTION
The home page feels a bit flat with all the text and limited imagery. I'm not sure adding these shadows improves that much, but maybe a tiny bit and they are subtle enough that at least I don't think they hurt anything.

### Before
<img width="1177" alt="Screen Shot 2023-01-20 at 11 35 35 AM" src="https://user-images.githubusercontent.com/101482/213780157-e36b99b8-ea31-40c5-bddf-6d36905be7fd.png">


### After
<img width="1177" alt="Screen Shot 2023-01-20 at 11 38 16 AM" src="https://user-images.githubusercontent.com/101482/213780135-5ae9a0dd-ed1a-48fb-9e8f-64d309445b23.png">
