### PR TITLE
More redis details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem "honeybadger", "~> 5.0"
 gem "okcomputer", "~> 1.18"
 
 gem "recaptcha", "~> 5.12"
+gem "redis", ">= 4.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.1.10)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -306,6 +307,10 @@ GEM
     rake (13.0.6)
     recaptcha (5.12.3)
       json
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.12.1)
+      connection_pool
     regexp_parser (2.6.1)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -458,6 +463,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   recaptcha (~> 5.12)
+  redis (>= 4.0.1)
   rsolr (>= 1.0, < 3)
   rspec-rails (~> 6.0)
   rubocop-rails (~> 2.16)

--- a/README.md
+++ b/README.md
@@ -63,14 +63,15 @@ Now that the new copy of `mt839rq8746` is downloaded, we can index it.
     ```
 4. If indexing on a remote server, we need to clear the caches:
    ```shell
-    cap prod remote_execute["cd vt/current; RAILS_ENV=production bin/rails tmp:cache:clear"]
+    cap prod remote_execute["cd vt/current; RAILS_ENV=production bin/rails r 'Rails.cache.clear'"]
    ```
 
 Here is an example of indexing new data onto a remote server. Make sure the SOLR_URL in the last step actually matches your index.
 ```shell
 cap stage deploy # put latest EAD file onto the server
 cap stage ssh
-SOLR_URL=http://sul-solr.stanford.edu/solr/nta-arclight-stage/  RAILS_ENV=production bin/rails arclight:destroy_index_docs tmp:cache:clear vt:index
+SOLR_URL=http://sul-solr.stanford.edu/solr/nta-arclight-stage/ RAILS_ENV=production bin/rails arclight:destroy_index_docs vt:index
+RAILS_ENV=production bin/rails r 'Rails.cache.clear'
 ```
 
 ### Note on the data in ArchivesSpace


### PR DESCRIPTION
- Add redis gem
- Document changed way to clear cache

My deploy failed:

```sh
rake stderr: The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem "redis", ">= 4.0.1"`
rake aborted!
Could not find cache store adapter for redis_cache_store (redis is not part of the bundle. Add it to your Gemfile.)
```