### PR TITLE
Revert to basic healthcheck

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -4,25 +4,3 @@
 # # /status/all to show all dependencies
 # # /status/<name-of-check> for a specific check (e.g. for nagios warning)
 OkComputer.mount_at = 'status'
-
-solr_url = ENV.fetch('SOLR_URL', 'http://127.0.0.1:8983/solr/blacklight-core')
-OkComputer::Registry.register 'solr', OkComputer::HttpCheck.new("#{solr_url}/admin/ping")
-
-redis_url = ENV.fetch('REDIS_URL', 'redis://localhost:6379/')
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: redis_url)
-
-#------------------------------------------------------------------------------
-# NON-CRUCIAL (Optional) checks, avail at /status/<name-of-check>
-#   - at individual endpoint, HTTP response code reflects the actual result
-#   - in /status/all, these checks will display their result text, but will not affect HTTP response code
-
-# Stacks service
-OkComputer::Registry.register 'stacks', OkComputer::HttpCheck.new('https://stacks.stanford.edu')
-
-# OEmbed service
-# This check will fail if purl is down.
-resource_url = "https://purl.stanford.edu/pv954fv1448"
-OkComputer::Registry.register 'embed',
-                              OkComputer::HttpCheck.new("https://embed.stanford.edu/iframe/?url=#{resource_url}")
-
-OkComputer.make_optional %w[stacks embed]


### PR DESCRIPTION
SOLR_URL was not defined, we were getting false failures. Until we fix that issue (see https://github.com/sul-dlss/vt-arclight/issues/524) we will remove those checks.