### PR TITLE
Remove references to shared_configs from cap deploys

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -34,7 +34,6 @@ require 'capistrano/rails'
 require 'capistrano/passenger'
 require 'dlss/capistrano'
 # require 'capistrano/sitemap_generator'
-require 'capistrano/shared_configs'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,6 +21,3 @@ set :linked_dirs, %w[log tmp/pids tmp/cache tmp/sockets vendor/bundle config/set
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
-
-# Update shared_configs before restarting app
-before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
Fixes #524

We also can remove the shared configs branches after this gets merged, I think