### PR TITLE
Subclass OembedController to pass extra params to sul-embed

### DIFF
--- a/app/components/oembed_viewer_component.rb
+++ b/app/components/oembed_viewer_component.rb
@@ -8,12 +8,13 @@ class OembedViewerComponent < Arclight::OembedViewerComponent
     @search = search
   end
 
-  # Rendered as data-* attributes on the viewer element for Arclight's JS
+  # Rendered as data-* attributes on the viewer element, passed to sul-embed
   def viewer_attrs
     {
-      controller: 'arclight-oembed',
-      arclight_oembed_url_value: @resource.href,
-      arclight_oembed_search: @search
+      controller: 'sul-embed',
+      sul_embed_hide_title_value: true,
+      sul_embed_url_value: @resource.href,
+      sul_embed_search_value: @search
     }
   end
 end

--- a/app/javascript/controllers/sul_embed_controller.js
+++ b/app/javascript/controllers/sul_embed_controller.js
@@ -1,0 +1,24 @@
+import OembedController from "arclight/oembed_controller";
+
+// Add support for additional parameters
+export default class SulEmbedController extends OembedController {
+  static values = {
+    hideTitle: Boolean,
+    search: String,
+    ...OembedController.values,
+  };
+
+  // Pass extra parameters to sul-embed
+  findOEmbedEndPoint(body) {
+    return super.findOEmbedEndPoint(body, this.getExtraParams());
+  }
+
+  // For a full list of parameters supported by the viewer, see:
+  // https://github.com/sul-dlss/sul-embed/blob/main/lib/embed/request.rb
+  getExtraParams() {
+    return {
+      ...(this.hideTitleValue && { hide_title: this.hideTitleValue }),
+      ...(this.searchValue && { search: this.searchValue }),
+    };
+  }
+}

--- a/spec/components/oembed_viewer_component_spec.rb
+++ b/spec/components/oembed_viewer_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OembedViewerComponent, type: :component do
   end
 
   it 'renders the viewer' do
-    expect(page).to have_selector 'div[data-controller="arclight-oembed"]'
+    expect(page).to have_selector 'div[data-controller="sul-embed"]'
   end
 
   it 'renders a link to the resource' do
@@ -21,10 +21,10 @@ RSpec.describe OembedViewerComponent, type: :component do
   end
 
   it 'passes the oembed URL to the viewer' do
-    expect(page).to have_selector 'div[data-arclight-oembed-url-value="example.com"]'
+    expect(page).to have_selector 'div[data-sul-embed-url-value="example.com"]'
   end
 
   it 'passes the search term to the viewer' do
-    expect(page).to have_selector 'div[data-arclight-oembed-search="mytext"]'
+    expect(page).to have_selector 'div[data-sul-embed-search-value="mytext"]'
   end
 end


### PR DESCRIPTION
This restores support for the "search within document" feature.

Also hides the viewer title, since it just duplicates the `<h1>` on
the page.
