### PR TITLE
Set highlight method to unified and increase maxAnalyzedChars limit

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -188,6 +188,16 @@
        <str name="spellcheck.extendedResults">true</str>
        <str name="spellcheck.collate">false</str>
        <str name="spellcheck.count">5</str>
+
+       <!-- The default character limit for highlighting in Solr is 52100.
+            The full_text_tesimv highlight field can be much longer.
+            With the UnifiedHighlighter (it is the default in Solr 9 but not 8)
+            there is no performance concern with increasing this limit.
+            There is a bug in Solr that prevents us from 
+            removing the limit by setting it to -1 -->
+       <str name="hl.method">unified</str>
+       <str name="hl.maxAnalyzedChars">20000000</str>
+       <str name="hl.fragsize">20</str>
      </lst>
     <arr name="last-components">
       <str>spellcheck</str>


### PR DESCRIPTION
Fixes #487

This sets the highlight method to unified, which is the default in Solr 9, but not in Solr 8 (which we are running in production). The `*_tesimv` field is already appropriately configured to take advantage of this more efficient highlighting method, see: https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html#schema-options-and-performance-considerations

By setting `hl.maxAnalyzedChars` to a high value we avoid missing highlight matches where the content of the `full_text_tesimv` field is longer than the default value of 52100 characters. The largest value in `full_text_tesimv` is roughly 12 million characters long.

Ideally we'd set `hl.maxAnalyzedChars` to -1 as a shortcut to set the value to the max integer value, but there is bug in Solr's `UnifiedHighlighter` that causes an error, see: https://issues.apache.org/jira/browse/SOLR-13121

I reduced the `hl.fragsize` from the default of 100 because the resulting snippets were longer than with the previous highlight settings.