### PR TITLE
Update arclight to v1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,9 +75,7 @@ group :deployment do
   gem 'dlss-capistrano'
 end
 
-# pin arclight to v1.0.* until we address some changes in v1.1.0
-# documented here: https://github.com/sul-dlss/vt-arclight/issues/608
-gem 'arclight', '~> 1.0.0'
+gem 'arclight', '~> 1.1'
 gem "cssbundling-rails", "~> 1.1"
 gem "devise", "~> 4.8"
 gem "devise-guests", "~> 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.5.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    arclight (1.0.1)
+    arclight (1.1.2)
       blacklight (>= 8.0.0, < 9)
       gretel
       rails (~> 7.0)
@@ -88,7 +88,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     bindex (0.8.1)
     blacklight (8.1.0)
       globalid
@@ -170,8 +170,8 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
       rake
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -180,7 +180,7 @@ GEM
       railties (>= 5.1, < 7.2)
     hashdiff (1.1.0)
     hashie (5.0.0)
-    honeybadger (5.6.0)
+    honeybadger (5.7.0)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -242,7 +242,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitar (0.9)
-    minitest (5.22.2)
+    minitest (5.22.3)
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
@@ -360,7 +360,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.13.1)
-    rubocop (1.62.0)
+    rubocop (1.62.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -469,7 +469,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  arclight (~> 1.0.0)
+  arclight (~> 1.1)
   blacklight (~> 8.0)
   bootsnap
   capistrano-passenger

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,7 +239,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # ===========================
 
     # Collection Show Page - Summary Section
-    config.add_summary_field 'creators_ssim', label: 'Creator'
+    config.add_summary_field 'creator_ssim', label: 'Creator'
     config.add_summary_field 'abstract_html_tesm', label: 'Abstract', helper_method: :render_html_tags
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssim', label: 'Language'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,12 @@
 # Methods that are mixed into the view context.
 module ApplicationHelper
   def render_item_extent(document:, **_kwargs)
-    extent = document["extent_ssm"].last
+    # Needed to support ArcLight 1.1 where extents that were previously
+    # stored separately (e.g. ['1 item(s)', '0:14:01']) are concatenated
+    # in the index (e.g. ['1 item(s) 0:14:01']). Selecting the last value
+    # maintains compatibility with the existing ArcLight 1.0 index.
+    extent = document['extent_ssm'].last.gsub('1 item(s)', '').strip
+
     # add duration label for time-based media
     case document["media_type_ssi"]
     when 'Moving Images', 'Audio'

--- a/app/models/arclight/parent.rb
+++ b/app/models/arclight/parent.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # Logic containing information about Solr_Ead "Parent"
+  # https://github.com/awead/solr_ead/blob/8cf7ffaa66e0e4c9c0b12f5646d6c2e20984cd99/lib/solr_ead/behaviors.rb#L54-L57
+  # Override of Arlight::Parent class so that breadcrumb links will continue to function
+  # after updating to ArcLight 1.1.
+  # TODO: This override can be removed if we re-index the collection and the parent_ids_ssim
+  #       field is populated.
+  class Parent
+    attr_reader :id, :label, :eadid, :level
+
+    def initialize(id:, label:, eadid:, level:)
+      @id = id
+      @label = label
+      @eadid = eadid
+      @level = level
+    end
+
+    def collection?
+      level == 'collection'
+    end
+
+    ##
+    # Concatenates the eadid and the id, to return an "id" in the context of
+    # Blacklight and Solr
+    # @return [String]
+    def global_id
+      return id if eadid == id
+
+      "#{eadid}#{id}"
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -15,10 +15,14 @@ class SolrDocument
   use_extension(Blacklight::Document::DublinCore)
 
   attribute :media_type, Blacklight::Types::String, 'media_type_ssi'
+  # Continue to use parent_ssim field from arclight versions prior to v1.1.0
+  # TODO: This must be removed if we re-index the collection and remove the
+  # Arclight::Parent override.
+  attribute :parent_ids, Blacklight::Types::Array, 'parent_ssim'
 
   # Suppress the display of extent badge when there is only one item
   def extent
-    result = Blacklight::Types::String.coerce(self['extent_ssm'])
-    result if result != '1 item(s)'
+    results = Blacklight::Types::Array.coerce(self['extent_ssm'])
+    results.any? { |v| v.include?('1 item(s)') } ? [] : results
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/lib/traject/vt_component_config.rb
+++ b/lib/traject/vt_component_config.rb
@@ -6,6 +6,11 @@ require_relative 'virtual_tribunals/normalized_title'
 settings do
   provide 'component_traject_config', __FILE__
   provide 'title_normalizer', 'VirtualTribunals::NormalizedTitle'
+  # Use legacy (before arclight v1.1.0) component identifier format for compatibility
+  # with existing ids. Removing this configuration will require a complete re-index and
+  # result in different component ids, which may not be desirable.
+  # See: https://github.com/projectblacklight/arclight/pull/1478
+  provide 'component_identifier_format', '%<root_id>s%<ref_id>s'
 end
 
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_component_config.rb"))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,6 +4,40 @@ require 'rails_helper'
 
 # rubocop:disable Layout/LineLength
 RSpec.describe ApplicationHelper do
+  describe '#render_item_extent' do
+    subject(:extent) { render_item_extent(document:) }
+
+    context 'when extent contains separate values for items and pages (ArcLight 1.0 index)' do
+      let(:document) do
+        SolrDocument.new('extent_ssm' => ['1 item(s)', '10 pages'])
+      end
+
+      it 'returns only the number of pages' do
+        expect(extent).to eq '10 pages'
+      end
+    end
+
+    context 'when extent contains concatenated values for items and pages (ArcLight 1.1 index)' do
+      let(:document) do
+        SolrDocument.new('extent_ssm' => ['1 item(s) 10 pages'])
+      end
+
+      it 'returns only the number of pages' do
+        expect(extent).to eq '10 pages'
+      end
+    end
+
+    context 'when media type is "Moving Images"' do
+      let(:document) do
+        SolrDocument.new('extent_ssm' => ['1 item(s) 0:14:19'], media_type_ssi: 'Moving Images')
+      end
+
+      it 'appends "duration" to the extent' do
+        expect(extent).to eq '0:14:19 duration'
+      end
+    end
+  end
+
   describe '#render_date_facet_links' do
     it 'is html safe' do
       expect(helper.render_date_facet_links(value: ['anything'])).to be_html_safe

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -8,16 +8,22 @@ RSpec.describe SolrDocument do
   describe '#extent' do
     subject { doc.extent }
 
-    context 'with 1' do
-      let(:attrs) { { extent_ssm: '1 item(s)' } }
+    context 'with 1 item and a separate pages value (ArcLight 1.0 index)' do
+      let(:attrs) { { extent_ssm: ['1 item(s)', '24 pages'] } }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be_empty }
     end
 
-    context 'with more than 1' do
-      let(:attrs) { { extent_ssm: '2 item(s)' } }
+    context 'with 1 item and a concatenated pages value (ArcLight 1.1 index)' do
+      let(:attrs) { { extent_ssm: ['1 item(s) 24 pages'] } }
 
-      it { is_expected.to eq '2 item(s)' }
+      it { is_expected.to be_empty }
+    end
+
+    context 'with more than 1 item' do
+      let(:attrs) { { extent_ssm: ['2 item(s)'] } }
+
+      it { is_expected.to include '2 item(s)' }
     end
   end
 end


### PR DESCRIPTION
Lauren has tested this update on stage and did not find any issues related to the update to ArcLight 1.1.

The update along with the changes in this PR are completely compatible with an index created by ArcLight 1.0 (the current index) or one created by ArcLight 1.1.

We can and should re-index the collection but there is no urgency to do so. I've documented a proposed process for re-indexing as well as the code that can be removed once the re-index is complete: https://github.com/sul-dlss/vt-arclight/issues/627