### PR TITLE
Pin arclight to v1.0.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,9 @@ group :deployment do
   gem 'dlss-capistrano'
 end
 
-gem 'arclight', '~> 1.0'
+# pin arclight to v1.0.* until we address some changes in v1.1.0
+# documented here: https://github.com/sul-dlss/vt-arclight/issues/608
+gem 'arclight', '~> 1.0.0'
 gem "cssbundling-rails", "~> 1.1"
 gem "devise", "~> 4.8"
 gem "devise-guests", "~> 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  arclight (~> 1.0)
+  arclight (~> 1.0.0)
   blacklight (~> 8.0)
   bootsnap
   capistrano-passenger


### PR DESCRIPTION
This will unblock dependency updates and let us address some changes in arclight in v1.1.0 after we get back from winter close.
Issue created to address changes and unpin: https://github.com/sul-dlss/vt-arclight/issues/608