### PR TITLE
Increase the default Capybara wait time for new headless chrome

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 Capybara.javascript_driver = :selenium_chrome_headless
+
+# The new headless chrome needs more default time.
+Capybara.default_max_wait_time = ENV['CI'] ? 30 : 10


### PR DESCRIPTION
Now that Capybara defaults to the new, full headless Chrome, some tests seem to be very flappy without more time, especially in CI.