### PR TITLE
Ignore search element for layout

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -64,6 +64,10 @@ main {
 .navbar-search {
   padding-bottom: 1.5rem;
 
+  search {
+    display: contents;
+  }
+
   > .container {
     justify-content: space-around;  // center the search box
   }


### PR DESCRIPTION
Fixes search box layout after changes in https://github.com/projectblacklight/blacklight/pull/3166

Related stanford-arclight fix: https://github.com/sul-dlss/stanford-arclight/pull/720

Before:
<img width="864" alt="Screenshot 2024-06-05 at 3 51 04 PM" src="https://github.com/sul-dlss/vt-arclight/assets/458247/d9fe81b5-1228-4455-946c-7d34bb0789c0">

After:
<img width="854" alt="Screenshot 2024-06-05 at 3 51 13 PM" src="https://github.com/sul-dlss/vt-arclight/assets/458247/6b291da8-db79-45bd-bb00-3cc6b979b38f">
