### PR TITLE
Run tests in a larger headless chrome window

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = Selenium::WebDriver::Chrome::Options.new
+  browser_options.add_argument('--window-size=1920,1080')
+  browser_options.add_argument('--headless')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
 Capybara.javascript_driver = :selenium_chrome_headless
 
 # The new headless chrome needs more default time.


### PR DESCRIPTION
This fixes some CI test failures due to visibility issues. These are the same settings we've used in other places (e.g., Spotlight).