### PR TITLE
Switch to new library logo in header and footer

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -4,7 +4,6 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrapOverrides';
 
-$logo-image: url(StanfordLibraries-logo-whitetext.svg);
 $logo-width: 200px;
 $logo-height: 35px;
 
@@ -35,6 +34,23 @@ main {
   .constraints-container {
     display: none; // Never show "back to search" or "start over" on an item show page.
   }
+}
+
+// Adds the new library logo to the header & footer
+// until we can update VT to use the component library
+.navbar-logo, .prefooter-logo {
+  background-color: white;
+  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
+  mask-repeat: no-repeat;
+  mask-position: 0 center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+}
+
+.prefooter-logo {
+  background-color: black;
+  width: 280px;
 }
 
 .al-masthead h1,

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,13 +2,11 @@
       <section id="pre-footer" class="py-4">
         <div class="container">
           <div class="row">
-          <div id="sul-footer-img" class="col-lg-2 col-md-3">
-            <%= link_to 'https://library.stanford.edu' do %>
-              <%= image_tag "sul-logo-stacked.svg", alt: "Stanford Libraries", height: 45 %>
-            <% end %>
-          </div>
+            <div id="sul-footer-img" class="d-flex w-auto">
+              <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
+            </div>
           <div class="col">
-            <ul class="list-unstyled d-flex mt-3">
+            <ul class="list-unstyled d-flex mt-3 pt-1">
               <li><a href="https://library-hours.stanford.edu/" class="px-2">Hours &amp; locations</a></li>
               <li><a href="https://mylibrary.stanford.edu/" class="px-2">My Account</a></li>
               <li><a href="https://library.stanford.edu/contact-us" class="px-2">Ask us</a></li>


### PR DESCRIPTION
This swaps out the old library logo for the new one without adding the component library until we can review/approve https://github.com/sul-dlss/vt-arclight/pull/695

<img width="486" alt="Screenshot 2025-01-17 at 11 56 11 AM" src="https://github.com/user-attachments/assets/8042a9ff-d8d6-4071-b9c7-04e66aa06d72" />
<img width="813" alt="Screenshot 2025-01-17 at 11 56 17 AM" src="https://github.com/user-attachments/assets/4402898f-9571-4692-a1cc-ba5e1e08f999" />
