### PR TITLE
Stop sending throttle notifications

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -48,10 +48,6 @@ module Rack
       match_data = request.env['rack.attack.match_data']
       now = match_data[:epoch_time]
 
-      if ((match_data[:limit] - match_data[:count]) < 5) || (match_data[:count] % 10).zero?
-        Honeybadger.notify('Throttling request', context: { ip: request.ip, path: request.path }.merge(match_data))
-      end
-
       headers = {
         'RateLimit-Limit' => match_data[:limit].to_s,
         'RateLimit-Remaining' => '0',


### PR DESCRIPTION
We send hundreds of these notifications an hour and they don't do us any good.  We've also turned these notification off on SearchWorks as well