### PR TITLE
Fix spacing on landing page heading

### DIFF
--- a/app/components/virtual_tribunals/header_component.html.erb
+++ b/app/components/virtual_tribunals/header_component.html.erb
@@ -3,7 +3,7 @@
 <div class='bg-faded al-masthead'>
   <div class="container">
     <div class="row align-items-center">
-      <div class="col-md-8">
+      <div class="col-md-8 my-2">
         <span class="h1"><%= t('.title') %></span>
       </div>
     </div>


### PR DESCRIPTION
This fixes a regression in the heading style on the landing page.

Before:
<img width="443" alt="Screenshot 2025-05-23 at 3 05 59 PM" src="https://github.com/user-attachments/assets/16d91ce4-6c07-4203-89c9-87c893f1e2cd" />

After:
<img width="499" alt="Screenshot 2025-05-23 at 3 05 54 PM" src="https://github.com/user-attachments/assets/c8385b95-379c-49b6-b184-d9b7cb8a3d1c" />
