### PR TITLE
Restore Redis as production cache store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,8 +61,8 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Use redis as the cache in production.
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL'), reconnect_attempts: 2 }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
Configuration to use Redis as the cache store in production was mistakenly removed in https://github.com/sul-dlss/vt-arclight/pull/612/commits/07ab31fb05b5535fff4e8f2a3a5f1f797a30968f