### PR TITLE
Rename exhibit resource type in facet config

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -16,7 +16,7 @@
 <div class="row explore">
   <%= render ExploreFacetComponent.new(facet:  blacklight_config.facet_fields['resource_type'],
                                        image: 'explore-facet-doc-type.png',
-                                       values: ['Official court transcripts', 'Exhibits', 'Final pleas and clemency pleas', 'Rules, rulings, and orders'],
+                                       values: ['Official court transcripts', 'Evidentiary exhibits', 'Final pleas and clemency pleas', 'Rules, rulings, and orders'],
                                        more: true) %>
   <%= render ExploreFacetComponent.new(facet:  blacklight_config.facet_fields['media_type'],
                                        image: 'explore-facet-media-format.png',


### PR DESCRIPTION
Fixes #676

<img width="235" height="346" alt="Screenshot 2025-07-28 at 4 51 14 PM" src="https://github.com/user-attachments/assets/bc1199a8-bfb9-444f-82bc-4e9892f8bd75" />
