### PR TITLE
Restore text-center on masthead heading/title

### DIFF
--- a/app/components/nuremberg/masthead_component.html.erb
+++ b/app/components/nuremberg/masthead_component.html.erb
@@ -1,6 +1,6 @@
 <div class='al-masthead bg-light'>
   <div class="container">
-    <span class="h1 d-flex justify-content-center"><%= heading %></span>
+    <span class="h1 d-flex justify-content-center text-center"><%= heading %></span>
 
     <nav class="nav-links" aria-label="browse">
       <ul class="navbar-nav justify-content-center d-flex flex-row">


### PR DESCRIPTION
I think we unintentionally broke the text centering at narrower screen widths when we fixed https://github.com/sul-dlss/vt-arclight/issues/722 

Before:
<img width="574" height="331" alt="Screenshot 2025-11-24 at 2 00 07 PM" src="https://github.com/user-attachments/assets/b03801b0-c6d5-46cf-9435-d7f87b9a60f0" />

After:
<img width="576" height="307" alt="Screenshot 2025-11-24 at 1 59 59 PM" src="https://github.com/user-attachments/assets/47fb6238-3f40-4ac9-bfce-40210cfa4ce8" />
