### PR TITLE
Set min recaptcha score so spam gets blocked

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -4,7 +4,7 @@
 class FeedbacksController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   def create
-    if verify_recaptcha(action: 'feedback')
+    if verify_recaptcha(action: 'feedback', minimum_score: 0.5)
       FeedbackMailer.submit_feedback(name: params[:name], email: params[:email],
                                      reporting_from: params[:reporting_from],
                                      message: params[:message]).deliver_now


### PR DESCRIPTION
As far as I can tell the recaptcha gem only blocks spam if you set minimum score.

https://github.com/ambethia/recaptcha/blob/3fadd21a0b122157e08b924cce4bdea6e4e94003/lib/recaptcha/reply.rb#L95